### PR TITLE
Add Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
-# effective-immediately
+# Effective Immediately
+
+## About
+
 A central hub for employers, employees, and people who've been recently laid off. We hope each of you can find helpful resources about handling or recovering from layoffs during a pandemic.
 
 ### Why does this exist?
+
 We got laid off in early March 2020, just as America's (and to our eye, the tech industry's) wave of layoffs was building. Our company asked us to stay another month to be an information conduit and to help our former colleagues-- also laid-off-- get connected to job opportunities.
 
 During that month, many more people were laid off and the spreadsheets, LinkedIn and Twitter postings, articles, forms, lists, and more kept piling up. The signal to noise ratio was becoming unmanageable, data about who was hiring was becoming stale day by day.
@@ -11,6 +15,7 @@ We don't know yet if that wave has crested, but we're still seeing layoff news e
 And thus, Effective Immediately was born.
 
 ### Who are we?
+
 Your core maintainers here are [Eben Dower](https://linkedin.com/in/eben-dower), [Kevin Landucci](https://linkedin.com/in/kevinlanducci), and [Krista Lane](https://linkedin.com/in/krista-lane), all former Senior Talent Managers at Triplebyte.
 
 [Jordan Helsloot](https://linkedin.com/in/jordanhelsloot) is a valued contributor to Effective Immediately and former Head of Talent Management at Triplebyte.
@@ -22,9 +27,11 @@ Although our origins began with Triplebyte, Effective Immediately has no remaini
 Lastly, a brief disclaimer: the three of us are not perfect. We chose an open-sourced model for this project because we know communities are better together. But 2/3 of us are new to Github, and we know our perspective can be siloed when we came from the same company in the same location. We're mostly assuming this will be consumed by people based in the United States, perhaps especially in California from which most of our professional networks originate.
 
 ### How to use this
+
 We are heavily inspired by how [jlevy](https://github.com/jlevy) organized his open source [Guide to Equity Compensation](https://github.com/jlevy/og-equity-compensation) (we'd been sharing this with candidates for a while-- thank you!) and so our current approach is for this readme to be comprehensive, well-organized, searchable and community-supported.
 
 ### How to contribute
+
 *See [contributing file](../master/contributing.md) for more detail and full attributions list.*
 
 Have you found other resources useful that you don't see here?
@@ -37,80 +44,136 @@ We welcome input (and give full credit for information we add or update) in two 
 
 Let's get to it.
 
-## Getting oneself sorted / taking care
+## Getting Started
+
 This section contains resources people who've been laid off may find useful right off the bat, before or while figuring out next steps.
 
 Getting laid off under any circumstance is no walk in the park, but during a pandemic is really hard. Be kind to yourself and give yourself a moment (or a few, whatever you need) to breathe and feel however you feel about it.
 
-#### Questions to ask immediately after notification
+### Questions to ask immediately after notification
+
 If HR doesn't answer these 7 questions for you, find out. [HBR: 7 questions to raise after you're laid off](https://hbr.org/2020/03/7-questions-to-raise-immediately-after-youre-laid-off). Although worth reading for the context, since it's paywalled, the basic questions are:
-- When do I receive my last paycheck? Will I receive severance pay? How long will I have to exercise my stock options? Does the company offer healthcare coverage after my last day, and if so for how long? Will you provide a reference for me? How can I get copies of my performance reviews, and by when? What will happen to my 401(k)?
-- We'd add, "Will I be able to keep my computer/related equipment?" If the answer is no, and you don't have a personal machine, ask if it's possible to keep it at least on loan until you find your next job. This is particularly important considering public access to computer facilities (like the library) is restricted right now, and many of your interviews will be conducted remotely using a computer that can connect to videoconferencing software. In general, it's worth asking for what would help make transitioning out easier (or otherwise be impactful for you), even if the answer is no.
+
+1. When do I receive my last paycheck?
+2. Will I receive severance pay? 
+3. How long will I have to exercise my stock options? 
+4. Does the company offer healthcare coverage after my last day, and if so for how long? 
+5. Will you provide a reference for me? 
+6. How can I get copies of my performance reviews, and by when? 
+7. What will happen to my 401(k)?
+
+We'd add:
+
+- Will I be able to keep my computer/related equipment? If the answer is no, and you don't have a personal machine, ask if it's possible to keep it at least on loan until you find your next job. This is particularly important considering public access to computer facilities (like the library) is restricted right now, and many of your interviews will be conducted remotely using a computer that can connect to videoconferencing software. In general, it's worth asking for what would help make transitioning out easier (or otherwise be impactful for you), even if the answer is no.
+
 - Depending on your situation (i.e. company size, layoff group size within 30-90 days, state, reason for layoff), you may be entitled to minimum standard severance benefits from your company after a layoff, such as 60 or 90-day notice (or equivalent pay), or from your state government in the form of additional unemployment benefits. We're not legal experts on any of the details, and in California at least, there are newly-announced exceptions due to COVID-19. So, if you feel your severance offer is lighter than it should be, you might ask whether the HR team has confirmed if your company meets those requirements. See: [CA WARN act FAQ](https://www.edd.ca.gov/About_EDD/coronavirus-2019/faqs/Warn.htm), and [Coronavirus and the WARN act](https://news.bloomberglaw.com/daily-labor-report/virus-driven-mass-worker-layoffs-could-soon-require-notice).
+
 - [Candor.co](https://candor.co/guides/layoff) has a simpler guide to handle closing out with your now-former employer.
 
-#### Self-care and resilience
+### Self-Care and Resilience
+
 - Maintaining one's health is critical, mentally and physically. Therapy can really help. If you're on a tight budget, here are five affordable ideas courtesy of [Healthline](https://www.healthline.com/health/therapy-for-every-budget). [Vox](https://www.vox.com/identities/2020/4/7/21207281/coronavirus-covid-19-how-to-find-a-therapist) also has ideas specific to finding a therapist (including insurance-friendly telehealth options) during COVID-19 shelter-in-place.
+
 - Here's a list on Lavandaire of [15 quarantine-friendly ideas](https://www.lavendaire.com/staycation/) for self-care and relaxation.
+
 - If relaxing isn't your speed right now, we made a [Spotify playlist](https://open.spotify.com/playlist/0VLUWd7h897BU1BBxSrbHh?si=Y9MlHqpsQEq475-dQU8YBQ) for being laid off in a pandemic that reads a bit like a breakup list. It's collaborative; feel free to add things that help(ed) you!
+
 - [Dealing with worry after a coronavirus layoff](https://qz.com/work/1830606/how-to-deal-with-worry-after-a-coronavirus-layoff/) - from Quartz
+
 - For many, spring 2020 is one of the most challenging times of our lives, even without a layoff involved. Adapting and building resilience will be key to moving forward, both to survive and (eventually) thrive. Here's the [APA's guide to building resilience](https://www.apa.org/topics/resilience).
 
-#### Broaden your community
-You aren't alone. Find others sharing what's helped them, and share what's helped you that might help others.
-- [Silver Lining](https://www.getsilverlining.com/) is a site for candidates and companies. It includes a talent dashboard for candidates to get discovered, job boards to browse, their own [collection of resources](https://www.getsilverlining.com/resources), and a growing Slack community offering support by career coaches and peers. Companies can browse candidates if they're hiring, or register their layoff to quickly connect their affected employees to support.
-- [HireClub](https://www.facebook.com/groups/hireclub/) is a Facebook group to help facilitate peer to peer job referrals, and it's moderated by a career coaching service aptly named HireClub.
-- [Elpha](https://elpha.com/) is a community for women in tech. Although the site as a whole is not specific to job hunting, there are tags and mini-communities within it, as well as job postings.
-- [Diversify Tech](https://www.diversifytech.co/) is a collection of resources for underrepresented people in tech, including job postings and various communities you might be interested to join.
-- [Hire Tech Ladies](https://www.hiretechladies.com/) is, like Elpha, a community for women in tech, but as the name suggests is more focused on hiring/getting hired.
-- Does your company (or previous companies you've worked at) have an alumni network you can connect with for support or job opportunities (or both)? What about other communities you might already be part of, like a church, club, gym, or university?
+## Understanding Benefits
 
-#### Unemployment benefits & healthcare
+_Intro Section_
+
+### Note on California
 
 Allegedly (we have not been able to verify this, will update if we do) CA state senate staffers are responding to constituents' concerns about problems with filing for unemployment. California residents who have trouble with filing for either state unemployment or healthcare benefits can try contacting them at Senator.[lastname]@senate.ca.gov. Even if they can't help you individually, it may not hurt to voice the pressing issues that probably a lot of people are facing. You can find your senator at findyourrep.legislature.ca.gov.
 
-##### Unemployment
+### Unemployment
+
 In most cases, if you were a full-time employee at the time of a layoff (and had been working full-time >12 months), you qualify for unemployment benefits.
 
 There are new, broader conditions (such as gig workers, part-timers and contractors) specifically during the state of emergency caused by COVID-19. Some benefits apply to everyone affected, and some apply only to those who lost jobs directly because of COVID-19.
 
 - [Mento](https://www.mento.co/relief-resources) has a free COVID-19 benefit-finder tool to help you determine (after a short quiz) which benefits you may qualify to receive for your situation. They also offer free or low-cost customized career coaching and guidance on many of the topics covered in this guide.
+
 - Your specific unemployment benefits will vary depending on your state, situation, etc. But you can start with [edd.ca.gov](https://edd.ca.gov) if you're in California, and the federal government also has info at [usa.gov/unemployment](https://www.usa.gov/unemployment).
+
 - In most cases you can apply for unemployment benefits as soon as you're no longer on company payroll. Beware of a common gotcha: if you learn you're laid off on Tuesday, but your company plans to call your "official last day" Friday, you can't apply for unemployment until Saturday.
+
 - Take care to complete your application as accurately as possible. One typo (for example, incorrectly filing your last day) can cause delays in getting paid, and the unemployment benefits providers are overwhelmed right now.
 
-##### Healthcare
-- People laid off are typically entitled to COBRA (your existing health coverage plan, but paid by you instead of your employer), but it is usually pretty expensive. If you have alternative healthcare options (such as a spouse's plan-- by the way, losing your job is a qualifying event to join outside of open enrollment) that may be your best route.
+### Healthcare
+
+People laid off are typically entitled to COBRA (your existing health coverage plan, but paid by you instead of your employer), but it is usually pretty expensive. If you have alternative healthcare options (such as a spouse's plan-- by the way, losing your job is a qualifying event to join outside of open enrollment) that may be your best route.
+
 - Covered California (for CA residents) may be another option.
+
 - You may find this article more helpful to [compare COBRA to Covered California](https://www.coveredca.com/individuals-and-families/special-circumstances/cobra/) in detail.
 
-#### All-in-one guides that cover some or all of the above (and below)
+### All-in-One Guides 
+
+These cover some or all of the above (and below):
+
 - [Kevin Landucci](https://linkedin.com/kevinlanducci) made a [30-day plan](https://docs.google.com/document/d/1bhuq69I1l8AjLcCcm_3kZofdtAT3C-d7paBKlC2C3lg/edit). The focus here is, "if you do nothing else in the first month post-layoff, do these things." Many additional resources linked within.
+
 - [Jordan Helsloot](https://linkedin.com/in/jordanhelsloot) assembled a guide he's calling "[Getting a job in the coronapocalypse](https://docs.google.com/document/d/1sssZI5H7LSH1V0eiTU7b2ERFi4GLDSS0Jw-PkXmVmtc/edit?usp=sharing)" for our former Triplebyte colleagues from resources collected and shared by all of us over March/April.
+
 - [Helen Wang](https://www.linkedin.com/in/helen-wang-5b8740b7/) assembled [this guide](https://docs.google.com/document/d/1nZ9s-0nQke6-lO6iaku-TZLVaWjxsM39z4P1smlDeQs/edit#heading=h.5j2gplfgz7dh) for their former Yelp colleagues, but it's broadly applicable. Covers basic details re: filing for unemployment, stimulus info at a glance, and maintaining some income while you job-search, etc.
+
 - [Patricia Mou](https://twitter.com/_patriciamou) compiled and regularly adds community-sourced resources into a [central job-searching list](https://docs.google.com/spreadsheets/d/1bbGCingPw5rnUTyC1WFcPq167rKR4ZaAEzm67ozjbds/edit#gid=1484275757). Every job board and talent list we've seen in the last month is on her list.
 
-## Applying to jobs
+## Next Job
+
+_Insert Intro Section_ 
+
+### Getting Organized
+
+We cannot recommend highly enough staying organized in this process. Don't trust yourself to remember everywhere you've applied in your head while so much is going on. At a minimum, track who you're talking to, from where, about which role, anticipated next steps, and how you feel about that opportunity.
+
+- Here's a basic [sample job search tracker](https://docs.google.com/spreadsheets/d/1qTpAQoZr8vu_yJZ2Du9f3sYgM0kldscqXdyHGfGQ0SU/edit#gid=0) you can adapt for yourself, courtesy of Jordan Helsloot.
+
+- [Huntr.co](https://huntr.co/) website-ifies this concept if you like pretty things.
+
+- Some people write daily schedules to keep themselves on track for their job search. If that works for you, awesome!
+
+- Others find goal-setting within a wider time frame to be more effective for them. An example: rather than spending 9-11am updating resume, 2-3pm preparing applications/requesting intros, etc, you might find it easier to set achievable goals you control, such as, "by the end of day Wednesday, I will have applied to 15 jobs." Break that down into manageable tasks (research/bookmark jobs, update resume, write cover letter, update tracker, etc.) that build up to the overall goal for that time period. Find what works for you.
+
+### Networking
+
+You aren't alone. Find others sharing what's helped them, and share what's helped you that might help others.
+
+- [Silver Lining](https://www.getsilverlining.com/) is a site for candidates and companies. It includes a talent dashboard for candidates to get discovered, job boards to browse, their own [collection of resources](https://www.getsilverlining.com/resources), and a growing Slack community offering support by career coaches and peers. Companies can browse candidates if they're hiring, or register their layoff to quickly connect their affected employees to support.
+
+- [HireClub](https://www.facebook.com/groups/hireclub/) is a Facebook group to help facilitate peer to peer job referrals, and it's moderated by a career coaching service aptly named HireClub.
+
+- [Elpha](https://elpha.com/) is a community for women in tech. Although the site as a whole is not specific to job hunting, there are tags and mini-communities within it, as well as job postings.
+
+- [Diversify Tech](https://www.diversifytech.co/) is a collection of resources for underrepresented people in tech, including job postings and various communities you might be interested to join.
+
+- [Hire Tech Ladies](https://www.hiretechladies.com/) is, like Elpha, a community for women in tech, but as the name suggests is more focused on hiring/getting hired.
+
+- Does your company (or previous companies you've worked at) have an alumni network you can connect with for support or job opportunities (or both)? What about other communities you might already be part of, like a church, club, gym, or university?
+
+### Applying to Jobs
+
 We suggest taking a moment to think about what you want to do next before you start applying to every job you see. "Beggars can't be choosers" may be ringing your ear off, but your time spent here may save you a lot of energy spinning your wheels on opportunities that aren't a good fit.
 
 Determine how much time/savings you can budget to find a new job-- both optimistically: assuming you maintain current quality of life/this will be pretty temporary, and pessimistically: assuming things will be terrible and you'll have to cut back on your expenses to stretch further. Your comfort with risk may vary from someone else's, but with so many unknowns, it's safer to *assume the worst* and *hope for the best*.
 
 Depending on your runway, you may decide the focus of your search is to find your next dream role to spend the next 2+ years. Or you might be looking for whatever you can do for the next year to keep the lights on.
 
-#### Getting organized
-We cannot recommend highly enough staying organized in this process. Don't trust yourself to remember everywhere you've applied in your head while so much is going on. At a minimum, track who you're talking to, from where, about which role, anticipated next steps, and how you feel about that opportunity.
-- Here's a basic [sample job search tracker](https://docs.google.com/spreadsheets/d/1qTpAQoZr8vu_yJZ2Du9f3sYgM0kldscqXdyHGfGQ0SU/edit#gid=0) you can adapt for yourself, courtesy of Jordan Helsloot.
-- [Huntr.co](https://huntr.co/) website-ifies this concept if you like pretty things.
-- Some people write daily schedules to keep themselves on track for their job search. If that works for you, awesome!
-- Others find goal-setting within a wider time frame to be more effective for them. An example: rather than spending 9-11am updating resume, 2-3pm preparing applications/requesting intros, etc, you might find it easier to set achievable goals you control, such as, "by the end of day Wednesday, I will have applied to 15 jobs." Break that down into manageable tasks (research/bookmark jobs, update resume, write cover letter, update tracker, etc.) that build up to the overall goal for that time period. Find what works for you.
-
-#### Updating resumes & writing cover letters
+### Updating Resumes & Writing Cover Letters
 
 - Kevin's [How to make a resume that doesn’t suck](https://docs.google.com/document/d/1ETeJBTejvnj4a69kUNzjXWzgPCeGzddXyWfsjrtH5zA/edit)
+
 - Kevin's [Light-hearted multidimensional approach for how to make a cover letter](https://docs.google.com/document/d/1B43BggM1nXkhyAbmanuFg6N7NP6mnIuWk_0xbp9acT8/edit)
+
 - Krista's [longform opinions](https://medium.com/@kristalane/a-treatise-on-resumes-23497dad165f) on resumes.
 
-#### Where to apply
+### Where to Apply
+
 Depending how you strategize your search, you may want to "spray and pray" applications to a lot of companies, or target your search, or something in between. Some people have recommended targeting "recession-proof" businesses like food/grocery industry.
 
 It does seem wise to at least consider the weaknesses or strengths of a business's revenue model and have questions prepared for you to assess the company's likelihood to sustain themselves (or grow responsibly to avoid triggering layoffs later when demand subsides). That said, even if you apply to hundreds of companies, a subset of your list should be companies (or roles) you'd be thrilled to work for-- your enthusiasm will shine in those interviews with much less effort than a throwaway application.
@@ -118,48 +181,75 @@ It does seem wise to at least consider the weaknesses or strengths of a business
 Regardless of your methods, in the current hiring climate we recommend spending some time evaluating how recently the job listing was added. As a rough guidance, if the posting is less than 2 weeks old: probably still active. 2-3 weeks old: suspicious, but could still be active. Be especially wary if that company has had layoffs during that time. 4+ weeks old: do not bother applying without confirming they are still hiring.
 
 It seemed overwhelming to list every job board here, but you can find many of them in these docs or elsewhere in this readme (like in the communities we've linked, or the employer section):
+
 - [Job Boards from “The Ultimate COVID Job Resource Stack”](https://docs.google.com/spreadsheets/d/1bbGCingPw5rnUTyC1WFcPq167rKR4ZaAEzm67ozjbds/edit#gid=1484275757)
+
 - [Emsi’s Job Postings Dashboard](https://www.economicmodeling.com/job-posting-dashboard/)
 
-## Preparing for interviews
+### Preparing for Interviews
+
 - [Jopwell’s Recap Article from their “Acing the Virtual Interview” Webinar](https://www.jopwell.com/thewell/posts/webinar-series-how-to-ace-the-virtual-interview?utm_medium=email&utm_source=mc&utm_campaign=event%20-%20community%20webinar%20recap%20-%2003/30/20&utm_source=Final+Jopwell+Candidate+Master+List&utm_campaign=094cb72b72-Event+-+Community+Webinar+Recap+-+03%2F30%2F20&utm_medium=email&utm_term=0_ed426c313b-094cb72b72-261802125)
+
 - [Twilio Unplugged](https://www.twilio.com/blog/unplugged-series) is offering a digital interview prep series (check their site for announcements on the next live event).
+
 - [Pathrise](https://www.pathrise.com/guides/how-to-get-a-job-at-company) offers interview prep guides for specific companies.
+
 - The [STAR method summarized](https://www.vawizard.org/wiz-pdf/STAR_Method_Interviews.pdf), and sample behavioral interview questions, courtesy of VA Wizard.
+
 - [viraptor's](https://github.com/viraptor) open-source list of [reverse interview questions](https://github.com/viraptor/reverse-interview/blob/master/README.md) (to ask your interviewer).
+
 - [Yangshung Tay's](https://yangshun.im/) [Tech Interview Handbook](https://yangshun.github.io/tech-interview-handbook/introduction) covers a lot, specifically for technical interviewing. We discovered it through the Questions to Ask section, which can apply to many roles/types of interviews.
+
 - This may feel hard to prioritize when the talent supply/demand balance is out of the candidate's favor, but [Maria Campbell](https://lowercaseopinions.com/about) wrote this thoughtful post on [identifying safe places to work](https://lowercaseopinions.com/safe-place) to avoid toxic environments.
+
 - FastCompany on [tips for virtual interview prep](https://www.fastcompany.com/90479058/5-things-you-must-do-to-have-a-successful-job-interview-on-video-during-the-covid-19-outbreak) during COVID-19 times
 
-## Offers
+## Offers and Negotiating
+
 In this market, it may be challenging to negotiate or otherwise expect to move forward in your salary growth. You may even take a side step to something entirely different (and potentially lower-paying) to keep yourself busy or pay the bills til you figure something else out. That's OK! There's no shame in that, and since tens of millions of people have been laid off this year, good recruiters won't think twice about what you do this year.
+
 - JLevy's [Comprehensive open source equity guide](https://github.com/jlevy/og-equity-compensation)
+
 - Jordan's [Decision-making rubric](https://docs.google.com/spreadsheets/d/1uhUTwj7WPdndOyhu7xS3BfBNEwtcc2BTHO2xmg-QGvs/edit#gid=832581606)-- helpful when comparing offers and you want to see the differences at the margin, but also useful to track weighted priorities/preferences between opportunities.
 
-## Employers - How you can help
+## Employers - How You Can Help
+
 We're glad you're here! We hope some of this is helpful and welcome input if you'd like to share wisdom with other companies.
 
-#### Before layoffs
+### Before Layoffs
+
 If you may need to lay off part of your company, consult your experts (of course), but please also read these:
+
 - [Andreessen Horowitz’s Guide to Planning and Managing Layoffs](https://a16z.com/2020/03/31/planning-and-managing-layoffs/)
+
 - [First Round’s How to Lead and Rally a Company through a Layoff](https://firstround.com/review/how-to-lead-and-rally-a-company-through-a-layoff/)
+
 - [Harvard Business Review on managing layoffs with compassion](https://hbr.org/2020/04/how-to-manage-coronavirus-layoffs-with-compassion?ab=hero-main-text)
 
-#### After layoffs
+### After Layoffs
+
 We're biased, but we recommend reading about our experience [running an outplacement team](https://triplebyte.com/blog/effective-immediately-supporting-your-people-after-layoffs) after Triplebyte's layoffs.
+
 - Here is our [tl;dr checklist](https://docs.google.com/document/d/1Uzx_kQLhM2DxujNN-V1dGajcBnHVKixGbts3b8jKZeA/edit) of that work, which contains links to templates you can use and documentation we wrote.
 
-#### Still hiring?
+### Still Hiring?
+
 If your company is unaffected by layoffs, or if layoffs did not impact hiring needs in other departments, you can do a few things to contribute toward industry-wide solutions:
 
-###### Source your candidate pipeline from layoff lists/trackers, either distributed by your investors or through sites listed below. Layoffs are currently affecting every sector (even parts of healthcare).
+#### Sourcing Candidates
+
+Source your candidate pipeline from layoff lists/trackers, either distributed by your investors or through sites listed below. Layoffs are currently affecting every sector (even parts of healthcare).
+
 - [ParachuteList](https://parachutelist.com/) claims to be "all the layoff lists, consolidated"
 - [layoffs.fyi](layoffs.fyi)
 - [Layoff-Aid](https://www.layoff-aid.com/faqforhiring)
 - [Candor.co](https://candor.co/layoff-list/)
 - [Awesome People List](https://docs.google.com/spreadsheets/d/1veoc3BJdELLkYpiJ1_ehXuKL_nK9ijROk8_bn0OmPso/edit#gid=1954995424) for candidates laid off from venture-backed companies.
 
-###### Repost open jobs frequently. Stale postings (2+ weeks old, especially if your company already had a round of layoffs) are unreliable when industry hiring needs are changing weekly. If you haven't already, add your open jobs to sites/lists like the following:
+#### Repost Open Jobs 
+
+Stale postings (2+ weeks old, especially if your company already had a round of layoffs) are unreliable when industry hiring needs are changing weekly. If you haven't already, add your open jobs to sites/lists like the following:
+
 - [Still hiring](https://www.stillhiring.io/)
 - [Silver Lining](https://www.getsilverlining.com/companies/hire)
 - [levels.fyi](https://www.levels.fyi/still-hiring/)
@@ -167,6 +257,8 @@ If your company is unaffected by layoffs, or if layoffs did not impact hiring ne
 - [Diversify Tech](https://www.diversifytech.co/post-a-job)
 - [Hire Tech Ladies](https://www.hiretechladies.com/partners/)
 
-## Employees - How you can help
+## Employees - How You Can Help
+
 - There's a section just for you and how to help your colleagues on our [recently-published blog post](https://triplebyte.com/blog/effective-immediately-supporting-your-people-after-layoffs). We hope it's useful.
+
 - QZ on [helping a friend through a coronavirus layoff](https://qz.com/work/1829796/what-to-say-when-someone-is-laid-off-because-of-coronavirus/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,38 @@
 # Effective Immediately
 
+<!-- toc -->
+
+- [About](#about)
+  * [Why does this exist?](#why-does-this-exist)
+  * [Who are we?](#who-are-we)
+  * [How to use this](#how-to-use-this)
+  * [How to contribute](#how-to-contribute)
+- [Getting Started](#getting-started)
+  * [Questions to ask immediately after notification](#questions-to-ask-immediately-after-notification)
+  * [Self-Care and Resilience](#self-care-and-resilience)
+- [Understanding Benefits](#understanding-benefits)
+  * [Note on California](#note-on-california)
+  * [Unemployment](#unemployment)
+  * [Healthcare](#healthcare)
+  * [All-in-One Guides](#all-in-one-guides)
+- [Next Job](#next-job)
+  * [Getting Organized](#getting-organized)
+  * [Networking](#networking)
+  * [Applying to Jobs](#applying-to-jobs)
+  * [Updating Resumes & Writing Cover Letters](#updating-resumes--writing-cover-letters)
+  * [Where to Apply](#where-to-apply)
+  * [Preparing for Interviews](#preparing-for-interviews)
+  * [Offers and Negotiating](#offers-and-negotiating)
+- [Employers - How You Can Help](#employers---how-you-can-help)
+  * [Before Layoffs](#before-layoffs)
+  * [After Layoffs](#after-layoffs)
+  * [Still Hiring?](#still-hiring)
+    + [Sourcing Candidates](#sourcing-candidates)
+    + [Repost Open Jobs](#repost-open-jobs)
+- [Employees - How You Can Help](#employees---how-you-can-help)
+
+<!-- tocstop -->
+
 ## About
 
 A central hub for employers, employees, and people who've been recently laid off. We hope each of you can find helpful resources about handling or recovering from layoffs during a pandemic.
@@ -13,38 +46,6 @@ During that month, many more people were laid off and the spreadsheets, LinkedIn
 We don't know yet if that wave has crested, but we're still seeing layoff news every week. By early April, we decided the work we'd done to help our colleagues might be useful to other people after we finished. We also kept finding resources in corners we didn't know about and wondered if there couldn't be a more community-supported, centralized way to share information.
 
 And thus, Effective Immediately was born.
-
-## Table of Contents
-
-   * [Effective Immediately](#effective-immediately)
-      * [About](#about)
-         * [Why does this exist?](#why-does-this-exist)
-         * [Who are we?](#who-are-we)
-         * [How to use this](#how-to-use-this)
-         * [How to contribute](#how-to-contribute)
-      * [Getting Started](#getting-started)
-         * [Questions to ask immediately after notification](#questions-to-ask-immediately-after-notification)
-         * [Self-Care and Resilience](#self-care-and-resilience)
-      * [Understanding Benefits](#understanding-benefits)
-         * [Note on California](#note-on-california)
-         * [Unemployment](#unemployment)
-         * [Healthcare](#healthcare)
-         * [All-in-One Guides](#all-in-one-guides)
-      * [Next Job](#next-job)
-         * [Getting Organized](#getting-organized)
-         * [Networking](#networking)
-         * [Applying to Jobs](#applying-to-jobs)
-         * [Updating Resumes &amp; Writing Cover Letters](#updating-resumes--writing-cover-letters)
-         * [Where to Apply](#where-to-apply)
-         * [Preparing for Interviews](#preparing-for-interviews)
-      * [Offers and Negotiating](#offers-and-negotiating)
-      * [Employers - How You Can Help](#employers---how-you-can-help)
-         * [Before Layoffs](#before-layoffs)
-         * [After Layoffs](#after-layoffs)
-         * [Still Hiring?](#still-hiring)
-            * [Sourcing Candidates](#sourcing-candidates)
-            * [Repost Open Jobs](#repost-open-jobs)
-      * [Employees - How You Can Help](#employees---how-you-can-help)
 
 ### Who are we?
 
@@ -242,7 +243,7 @@ We'll keep adding to these resources, but here's a list to start with:
 
 - FastCompany on [tips for virtual interview prep](https://www.fastcompany.com/90479058/5-things-you-must-do-to-have-a-successful-job-interview-on-video-during-the-covid-19-outbreak) during COVID-19 times
 
-## Offers and Negotiating
+### Offers and Negotiating
 
 In this market, it may be challenging to negotiate or otherwise expect to move forward in your salary growth. You may even take a side step to something entirely different (and potentially lower-paying) to keep yourself busy or pay the bills til you figure something else out. That's OK! There's no shame in that, and since tens of millions of people have been laid off this year, good recruiters won't think twice about what you do this year.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Effective Immediately
 
+## About
+
+A central hub for employers, employees, and people who've been recently laid off. We hope each of you can find helpful resources about handling or recovering from layoffs during a pandemic.
+
+### Table of Contents
+
 <!-- toc -->
 
 - [About](#about)
@@ -32,10 +38,6 @@
 - [Employees - How You Can Help](#employees---how-you-can-help)
 
 <!-- tocstop -->
-
-## About
-
-A central hub for employers, employees, and people who've been recently laid off. We hope each of you can find helpful resources about handling or recovering from layoffs during a pandemic.
 
 ### Why does this exist?
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,38 @@ We don't know yet if that wave has crested, but we're still seeing layoff news e
 
 And thus, Effective Immediately was born.
 
+## Table of Contents
+
+   * [Effective Immediately](#effective-immediately)
+      * [About](#about)
+         * [Why does this exist?](#why-does-this-exist)
+         * [Who are we?](#who-are-we)
+         * [How to use this](#how-to-use-this)
+         * [How to contribute](#how-to-contribute)
+      * [Getting Started](#getting-started)
+         * [Questions to ask immediately after notification](#questions-to-ask-immediately-after-notification)
+         * [Self-Care and Resilience](#self-care-and-resilience)
+      * [Understanding Benefits](#understanding-benefits)
+         * [Note on California](#note-on-california)
+         * [Unemployment](#unemployment)
+         * [Healthcare](#healthcare)
+         * [All-in-One Guides](#all-in-one-guides)
+      * [Next Job](#next-job)
+         * [Getting Organized](#getting-organized)
+         * [Networking](#networking)
+         * [Applying to Jobs](#applying-to-jobs)
+         * [Updating Resumes &amp; Writing Cover Letters](#updating-resumes--writing-cover-letters)
+         * [Where to Apply](#where-to-apply)
+         * [Preparing for Interviews](#preparing-for-interviews)
+      * [Offers and Negotiating](#offers-and-negotiating)
+      * [Employers - How You Can Help](#employers---how-you-can-help)
+         * [Before Layoffs](#before-layoffs)
+         * [After Layoffs](#after-layoffs)
+         * [Still Hiring?](#still-hiring)
+            * [Sourcing Candidates](#sourcing-candidates)
+            * [Repost Open Jobs](#repost-open-jobs)
+      * [Employees - How You Can Help](#employees---how-you-can-help)
+
 ### Who are we?
 
 Your core maintainers here are [Eben Dower](https://linkedin.com/in/eben-dower), [Kevin Landucci](https://linkedin.com/in/kevinlanducci), and [Krista Lane](https://linkedin.com/in/krista-lane), all former Senior Talent Managers at Triplebyte.


### PR DESCRIPTION
Closes #7 

The table of contents is generated by [gh-mk-toc](https://github.com/ekalinin/github-markdown-toc) which looks pretty good. It's manual to add to the README.md but anyway I think we want to move this to a Jekyll or some static site builder compatible with GitHub Pages so that this content is a website and not meant to be browsed directly through the GH interface, thus making it more friendly to non-technical people as it grows.